### PR TITLE
还原为 ssh2 的默认值

### DIFF
--- a/tasks/scp.js
+++ b/tasks/scp.js
@@ -15,8 +15,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('scp', 'copy files to remote server.', function() {
     var options = this.options({
       host: 'localhost',
-      username: 'lepture',
-      password: '123'
+      username: 'lepture'
     });
 
     var done = this.async();


### PR DESCRIPTION
有时只需要传入 `privateKey`，`password` 还是是用默认值的好
