### PR TITLE
prompt for scp password

### DIFF
--- a/tasks/scp.js
+++ b/tasks/scp.js
@@ -84,7 +84,9 @@ module.exports = function(grunt) {
       });
     }
 
-    if (options.password === true) {
+    if (options.password) {
+      execUploads();
+    } else {
       inquirer.prompt([{
         name: 'password',
         message: 'password: ',
@@ -95,8 +97,6 @@ module.exports = function(grunt) {
         execUploads();
       });
     }
-    else {
-      execUploads();  
-    }
+
   });
 };


### PR DESCRIPTION
Using without a password doesn't prompt for it.
This should fix it.
