### PR TITLE
CWD causes the script to bail when it's not set

### DIFF
--- a/tasks/scp.js
+++ b/tasks/scp.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
           filename = filepath;
           filepath = path.join(fileObj.cwd, filepath);
         } else {
-          filename = path.relative(fileObj.orig.cwd, filepath);
+          filename = path.relative(fileObj.orig.cwd || '', filepath);
         }
         destfile = path.join(fileObj.dest, filename);
         client.upload(filepath, destfile, cb);


### PR DESCRIPTION
`fileObj.orig.cwd` can return undefined which will kill the `path.relative` call with a warning. This gives it a default empty string to base the relative off of.